### PR TITLE
Specify directory to read files from

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,17 @@
+use std::{env, process};
 use code_visualizer::renderer;
 
 fn main() {
-    let paths = renderer::get_unicode_files_in_dir("./input/");
+    let mut code_dir = env::args()
+        .nth(1)
+        .unwrap_or_else(|| {
+            println!("USAGE: code-visualizer <directory>");
+            process::exit(1);
+        });
+    if !code_dir.ends_with('/') {
+        code_dir.push('/');
+    }
+    let paths = renderer::get_unicode_files_in_dir(&code_dir);
 
     // render files to image, and store in ./output.png
     renderer::render(&paths, 100, 16.0 / 9.0, true, true)


### PR DESCRIPTION
Saw this project on Reddit, neat little program!

Because of your unconventional code style (in lib.rs more than main), it makes this project rather difficult to contribute to.

Nonetheless, I hope this change is okay. Alternatively, you could make this backwards compatible by having the `unwrap_or_else` return `String::from("./input/")`