### PR TITLE
Fix typos and prettify md/yaml files

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,21 +2,20 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -1,19 +1,17 @@
 # rs-code-visualizer
 
-**rs-code-visualizer** takes all source code / UTF-8 encodable text that you put in the ``./input/`` folder, and renders them to one PNG image. These images show the shape and size of files, but not the exact characters inside the files. If you add non UTF-8 compatible files, they will be skipped from the render. It syntax highlights any type of file it understands.
+**rs-code-visualizer** takes all source code / UTF-8 encodable text that you put in the `./input/` folder, and renders them to one PNG image. These images show the shape and size of files, but not the exact characters inside the files. If you add non UTF-8 compatible files, they will be skipped from the render. It syntax highlights any type of file it understands.
 
 This repo's render of [sloganking/My-Own-OS](https://github.com/sloganking/My-Own-OS/tree/6e555c05ce46dcc13904eb41cc4b3ccde61032b5):
- 
-![](./assets/code.png)
 
+![](./assets/code.png)
 
 ## Usage
 
 - Install [the Rust programming language.](https://www.rust-lang.org/)
-- Put all files you want to visualize in the ``./input/`` folder (they can be in deeper folders).
-- Open a terminal in this repo's directory, and run ``cargo run --release``
-- See the finished render in ``./output.png``
-
+- Put all files you want to visualize in the `./input/` folder (they can be in deeper folders).
+- Open a terminal in this repo's directory, and run `cargo run --release`
+- See the finished render in `./output.png`
 
 ### To document
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub mod renderer {
             return None;
         }
 
-        //> determine image dimensions based on num of lines and contraints
+        //> determine image dimensions based on num of lines and constraints
 
             //> initialize variables
                 let mut last_checked_aspect_ratio: f64 = f64::MAX;


### PR DESCRIPTION
Resolved via command:

    codespell -L crate
    prettier -w .